### PR TITLE
Improve FCP by inlining icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;display=swap" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;display=swap" rel="stylesheet"></noscript>
 <link rel="stylesheet" href="style.css">
-<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" defer></script>
 </head>
 
 <body class="min-h-screen flex flex-col items-center text-white font-[Inter] tracking-tight overflow-x-hidden bg-slate-950">
@@ -51,26 +50,26 @@
   </p>
   <a href="https://wildercasino.example.com/affiliate-link" target="_blank" rel="noopener" class="group relative inline-flex items-center justify-center px-10 py-4 bg-gradient-to-r from-cyan-500 to-indigo-500 rounded-xl shadow-xl font-semibold text-lg hover:from-cyan-400 hover:to-indigo-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 transition-all duration-200 opacity-0 translate-y-8 animate-fade-in-up delay-[450ms]">
     Перейти на Wilder зеркало
-    <i data-lucide="arrow-right" class="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform duration-200"></i>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform duration-200"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
   </a>
 
   <!-- ПРОМОКОД -->
   <div class="w-full max-w-md bg-slate-900/60 border border-slate-700/40 rounded-2xl p-6 shadow-lg ring-1 ring-inset ring-white/10 space-y-4 opacity-0 translate-y-8 animate-fade-in-up delay-[550ms]">
     <h2 class="flex items-center space-x-2 text-xl font-semibold">
-      <i data-lucide="ticket" class="w-5 h-5 text-cyan-400"></i>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-cyan-400"><path d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2Z"/><path d="M13 5v2"/><path d="M13 17v2"/><path d="M13 11v2"/></svg>
       <span>Эксклюзивный промокод</span>
     </h2>
 
     <div class="flex items-center justify-between bg-slate-800/70 rounded-lg px-4 py-3" role="group">
       <span id="promoCode" class="font-mono text-lg tracking-widest text-cyan-300 select-all">KRETUTLTNYG</span>
       <button id="copyBtn" aria-label="Скопировать промокод" class="flex items-center text-sm font-semibold text-cyan-400 hover:text-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-500 rounded-md px-2 py-1 transition-all">
-        <i data-lucide="copy" class="w-4 h-4"></i>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
         <span class="sr-only sm:not-sr-only ml-1">Скопировать</span>
       </button>
     </div>
 
     <p class="text-sm text-slate-400 flex items-center justify-center space-x-2">
-      <i data-lucide="calendar" class="w-4 h-4 text-cyan-400"></i>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-cyan-400"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
       <span>Действительно до&nbsp;<time datetime="2025-07">Июль 2025</time></span>
     </p>
     <p class="text-sm text-slate-400">
@@ -84,15 +83,15 @@
   <!-- ИНДИКАТОРЫ ДОВЕРИЯ -->
   <div class="flex flex-col sm:flex-row sm:space-x-10 space-y-4 sm:space-y-0 pt-4 opacity-0 translate-y-8 animate-fade-in-up delay-[750ms]">
     <div class="flex items-center space-x-2">
-      <i data-lucide="shield-check" class="w-5 h-5 text-green-400"></i>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-400"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg>
       <span class="text-sm font-medium text-slate-300">Лицензия и безопасность</span>
     </div>
     <div class="flex items-center space-x-2">
-      <i data-lucide="zap" class="w-5 h-5 text-yellow-400"></i>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-yellow-400"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg>
       <span class="text-sm font-medium text-slate-300">Мгновенные выводы</span>
     </div>
     <div class="flex items-center space-x-2">
-      <i data-lucide="gift" class="w-5 h-5 text-pink-400"></i>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-pink-400"><rect x="3" y="8" width="18" height="4" rx="1"/><path d="M12 8v13"/><path d="M19 12v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7"/><path d="M7.5 8a2.5 2.5 0 0 1 0-5A4.8 8 0 0 1 12 8a4.8 8 0 0 1 4.5-5 2.5 2.5 0 0 1 0 5"/></svg>
       <span class="text-sm font-medium text-slate-300">Приветственный бонус</span>
     </div>
   </div>
@@ -110,7 +109,7 @@
       <div class="py-4">
         <button class="faq-toggle w-full flex justify-between items-center text-lg font-medium text-left focus:outline-none">
           <span>Как использовать Wilder зеркало?</span>
-          <i data-lucide="chevron-down" class="w-5 h-5 transition-transform"></i>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 transition-transform"><path d="m6 9 6 6 6-6"/></svg>
         </button>
         <p class="faq-content mt-2 text-slate-300 text-sm leading-relaxed hidden">
           Перейдите по ссылке на этой странице: она ведёт на актуальное Wilder зеркало. Авторизуйтесь или зарегистрируйтесь и играйте без ограничений.
@@ -120,7 +119,7 @@
       <div class="py-4">
         <button class="faq-toggle w-full flex justify-between items-center text-lg font-medium text-left focus:outline-none">
           <span>Что делать, если зеркало недоступно?</span>
-          <i data-lucide="chevron-down" class="w-5 h-5 transition-transform"></i>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 transition-transform"><path d="m6 9 6 6 6-6"/></svg>
         </button>
         <p class="faq-content mt-2 text-slate-300 text-sm leading-relaxed hidden">
           Подключите VPN или подпишитесь на наш Telegram-канал, где ежедневно публикуем рабочие зеркала Wilder Casino.
@@ -130,7 +129,7 @@
       <div class="py-4">
         <button class="faq-toggle w-full flex justify-between items-center text-lg font-medium text-left focus:outline-none">
           <span>Есть ли приложение для обхода блокировки?</span>
-          <i data-lucide="chevron-down" class="w-5 h-5 transition-transform"></i>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 transition-transform"><path d="m6 9 6 6 6-6"/></svg>
         </button>
         <p class="faq-content mt-2 text-slate-300 text-sm leading-relaxed hidden">
           Да. Скачайте мобильное приложение Wilder Casino на нашем сайте: оно автоматически соединяется с актуальным зеркалом.
@@ -202,7 +201,7 @@
     <div class="flex justify-center">
       <a href="#leave-review" class="group inline-flex items-center px-8 py-3 bg-slate-800/70 border border-slate-700/40 rounded-lg font-medium text-sm text-slate-200 hover:bg-slate-700/60 focus:outline-none focus:ring-2 focus:ring-cyan-500 transition-all">
         Оставь свой отзыв
-        <i data-lucide="message-circle" class="w-4 h-4 ml-2 group-hover:translate-x-0.5 transition-transform"></i>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 ml-2 group-hover:translate-x-0.5 transition-transform"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg>
       </a>
     </div>
   </section>
@@ -222,37 +221,33 @@
 .bg-noise{background-image:url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMiIgaGVpZ2h0PSIyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxIiBoZWlnaHQ9IjEiIGZpbGw9IiNmZmYiIC8+PHJlY3QgeD0iMSIgeT0iMSIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0iI2ZmZiIgLz48L3N2Zz4=");}
 </style>
 
-<!-- ───────────────────── СКРИПТЫ ───────────────────── -->
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  lucide.createIcons();
+  const copyBtn = document.getElementById('copyBtn');
+  const promoCode = document.getElementById('promoCode');
+  const copyIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>';
+  const checkIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4"><path d="M20 6 9 17l-5-5"/></svg>';
 
-// Копирование промокода
-const copyBtn = document.getElementById('copyBtn');
-const promoCode = document.getElementById('promoCode');
-copyBtn?.addEventListener('click', async () => {
-  try {
-    await navigator.clipboard.writeText(promoCode.textContent.trim());
-    copyBtn.innerHTML = '<i data-lucide="check" class="w-4 h-4"></i>';
-    lucide.createIcons();
-    setTimeout(() => {
-      copyBtn.innerHTML = '<i data-lucide="copy" class="w-4 h-4"></i><span class="sr-only sm:not-sr-only ml-1">Скопировать</span>';
-      lucide.createIcons();
-    }, 2000);
-  } catch {
-    alert('Не удалось скопировать промокод. Скопируйте вручную.');
-  }
-});
-
-// FAQ аккордеоны
-document.querySelectorAll('.faq-toggle').forEach(btn => {
-  btn.addEventListener('click', () => {
-    const content = btn.nextElementSibling;
-    const icon = btn.querySelector('i');
-    const expanded = content.classList.toggle('hidden') === false;
-    icon.style.transform = expanded ? 'rotate(180deg)' : 'rotate(0deg)';
+  copyBtn?.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(promoCode.textContent.trim());
+      copyBtn.innerHTML = checkIcon;
+      setTimeout(() => {
+        copyBtn.innerHTML = copyIcon + '<span class="sr-only sm:not-sr-only ml-1">Скопировать</span>';
+      }, 2000);
+    } catch {
+      alert('Не удалось скопировать промокод. Скопируйте вручную.');
+    }
   });
-});
+
+  document.querySelectorAll('.faq-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const content = btn.nextElementSibling;
+      const icon = btn.querySelector('svg');
+      const expanded = content.classList.toggle('hidden') === false;
+      icon.style.transform = expanded ? 'rotate(180deg)' : 'rotate(0deg)';
+    });
+  });
 });
 </script>
 


### PR DESCRIPTION
## Summary
- inline all lucide icons directly in the HTML
- drop the large lucide.js dependency
- rewrite the clipboard/FAQ script to work with inline SVG icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68797e86a6c4832d9173f1dfe3d60cc7